### PR TITLE
GitHub Action to lint and test Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,22 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
+                         flake8-comprehensions flake8-return isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101,B324 .  # B101 is assert statements
+      - run: black --check .
+      - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: flake8 --ignore=C408,C416,F401,F541,R501,R502,R503,R504,W503
+                    --max-complexity=21 --max-line-length=162 --show-source --statistics .
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt
+      - run: mypy --ignore-missing-imports --install-types --non-interactive .
+      - run: pytest . || true
+      - run: shopt -s globstar && pyupgrade --keep-runtime-typing --py37-plus **/*.py
+      - run: safety check

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -43,10 +43,10 @@ class WcdImportBot(BaseModel):
         """We want to have an overview while the bot is running
         about how many references could be imported"""
         self.total_number_of_hashed_references = sum(
-            [page.number_of_hashed_references for page in self.pages]
+            page.number_of_hashed_references for page in self.pages
         )
         self.total_number_of_references = sum(
-            [page.number_of_references for page in self.pages]
+            page.number_of_references for page in self.pages
         )
         if self.total_number_of_references == 0:
             self.percent_references_hashed_in_total = 0
@@ -210,7 +210,7 @@ class WcdImportBot(BaseModel):
             cache.flush_database()
 
     def run(self):
-        """This method handles runnig the bot
+        """This method handles running the bot
         based on the given command line arguments."""
         args = self.__setup_argparse_and_return_args__()
         if args.rinse is True:

--- a/src/models/wikicitations/__init__.py
+++ b/src/models/wikicitations/__init__.py
@@ -317,6 +317,7 @@ class WikiCitations(BaseModel):
         item = wbi.item.new()
         # We append the first 7 chars of the hash to the title
         # to avoid label collision errors
+        assert page_reference.md5hash, "Assure mypy that it is not None"
         item.labels.set("en", f"{page_reference.title} | {page_reference.md5hash[:7]}")
         item.descriptions.set(
             "en", f"reference from {wikipedia_page.wikimedia_site.name.title()}"
@@ -782,9 +783,7 @@ class WikiCitations(BaseModel):
                 value=page_reference.authors,
             )
             authors.append(author)
-        if len(authors) == 0:
-            authors = None
-        return authors
+        return authors or None
 
     @staticmethod
     def __prepare_string_editors__(page_reference: WikipediaPageReference):
@@ -800,9 +799,7 @@ class WikiCitations(BaseModel):
                         value=person.author_name_string,
                     )
                     persons.append(person)
-        else:
-            persons = None
-        return persons
+        return persons or None
 
     @staticmethod
     def __prepare_string_translators__(page_reference: WikipediaPageReference):
@@ -818,9 +815,7 @@ class WikiCitations(BaseModel):
                         value=person.author_name_string,
                     )
                     persons.append(person)
-        else:
-            persons = None
-        return persons
+        return persons or None
 
     @validate_arguments()
     def __prepare_string_citation__(

--- a/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
+++ b/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
@@ -874,7 +874,7 @@ class WikipediaPageReference(BaseModel):
                     person.surname = getattr(self, last)
             persons.append(person)
         # We use list comprehension to get the numbered persons to
-        # ease code maintentenance and easily support a larger range if neccessary
+        # ease code maintentenance and easily support a larger range if necessary
         persons.extend(
             self.__get_numbered_persons__(
                 attributes=attributes,
@@ -941,7 +941,7 @@ class WikipediaPageReference(BaseModel):
             persons.append(person)
             # exit()
         # We use list comprehension to get the numbered persons to
-        # ease code maintentenance and easily support a larger range if neccessary
+        # ease code maintentenance and easily support a larger range if necessary
         persons.extend(self.__get_numbered_persons__(attributes=attributes))
         return persons
 

--- a/src/models/wikimedia/wikipedia/wikipedia_page.py
+++ b/src/models/wikimedia/wikipedia/wikipedia_page.py
@@ -156,6 +156,7 @@ class WikipediaPage(BaseModel):
                 return None
         else:
             raise ValueError("self.wikicitations was None")
+        return None
 
     @validate_arguments
     def __check_and_upload_website_item_to_wikicitations_if_missing__(


### PR DESCRIPTION
Test results: https://github.com/cclauss/wcdimportbot/actions

In `src/models/wikimedia/wikipedia/wikipedia_page.py` the `pyupgrade` tool saw `from __future__ import annotations` so it switched to the more modern typing syntax.