### PR TITLE
Streamline author_name_string()

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -185,7 +185,7 @@ class WcdImportBot(BaseModel):
                         latest_revision_date=page.editTime(),
                         latest_revision_id=page.latest_revision_id,
                         page_id=page.pageid,
-                        title=str((page.title())),
+                        title=str(page.title()),
                         wikimedia_site=self.wikimedia_site,
                         wikitext=page.text,
                     )

--- a/src/models/person/__init__.py
+++ b/src/models/person/__init__.py
@@ -21,7 +21,7 @@ class Person(BaseModel):
     @property
     def author_name_string(self) -> Optional[str]:
         """We hardcode western cultural name ordering pattern here with the
-        order "givenname surname".  We use str.strip() because name has
+        order "givenname surname".  We use str.strip() because no name has
         significant whitespace at the beginning or end of the string"""
         return (
             (self.name_string or "").strip()

--- a/src/models/person/__init__.py
+++ b/src/models/person/__init__.py
@@ -20,18 +20,11 @@ class Person(BaseModel):
 
     @property
     def author_name_string(self) -> Optional[str]:
-        """We hardcode western cultural name ordering pattern here with the order "givenname surname" """
-        if self.name_string is None:
-            string = ""
-            if self.given is not None:
-                string += self.given
-            if self.surname is not None:
-                string += " " + self.surname
-        else:
-            string = self.name_string
-        # We strip spaces to avoid a MWAPIError when a space appears in the beginning of the string
-        string = string.lstrip()
-        if len(string) > 0:
-            return string
-        else:
-            return None
+        """We hardcode western cultural name ordering pattern here with the
+        order "givenname surname".  We use str.strip() because name has
+        significant whitespace at the beginning or end of the string"""
+        return (
+            (self.name_string or "").strip()
+            or f"{self.given or ''} {self.surname or ''}".strip()
+            or None
+        )


### PR DESCRIPTION
Do we really need Optional everywhere?

If I am asking for a Person's name, I ALWAYS expect to get a str back.  That str can be "" if the name is not known but a name is a str.  Similarly, a bool is either True or False -- That is the definition of a bool.  An int is a whole number...  Is there some database or Pydantic reason for using Optional everywhere?

Without the Optional bits, this function would be even more streamlined...
```
    def author_name_string(self) -> str:
        return self.name_string.strip() or f"{self.given} {self.surname}".strip()
```

On function naming:  The object is a `Person` but the property is called `author_name_string()` which assumes that all persons are authors.  Would it be better to name this method `full_name()` instead?

Also, `given` is not as intuitive/self-documenting as `given_name`.