### PR TITLE
Fix template_name when there are multiple alternatives

### DIFF
--- a/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
+++ b/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
@@ -720,7 +720,7 @@ class WikipediaPageReference(BaseModel):
         # Mypy warns that the following could add None to the list,
         # but that cannot happen.
         return [
-            self.__get_numbered_person__(
+            self.__get_numbered_person__(  # type: ignore
                 attributes=attributes,
                 number=number,
                 role=role,
@@ -838,7 +838,7 @@ class WikipediaPageReference(BaseModel):
             self.wikidata_qid = self.first_parameter
         elif self.template_name == "url":
             # crudely detect if url in first_parameter
-            if "://" in self.first_parameter:
+            if "://" in (self.first_parameter or ""):
                 self.url = self.first_parameter
         elif self.template_name == "isbn":
             self.isbn = self.first_parameter

--- a/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
+++ b/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
@@ -832,7 +832,7 @@ class WikipediaPageReference(BaseModel):
 
     def __parse_first_parameter__(self) -> None:
         # pseudo code
-        if self.template_name == ("cite q" or "citeq"):
+        if self.template_name in ("cite q", "citeq"):
             # We assume that the first parameter is the Wikidata QID
             # TODO add crude check?
             self.wikidata_qid = self.first_parameter


### PR DESCRIPTION
```
>>> ("cite q" or "citeq")
'cite q'
>>> ("cite q", "citeq")
('cite q', 'citeq')
```