### PR TITLE
GitHub Action: Run pytests that do not require userid and password

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -19,6 +19,7 @@ jobs:
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: cp config.py.sample config.py
-      - run: pytest . || true
+      # Tests in test_wcdimportbot.py and test_wikicitations.py require a valid userid and password
+      - run: pytest --ignore=tests/test_wcdimportbot.py --ignore=tests/test_wikicitations.py .
       - run: shopt -s globstar && pyupgrade --keep-runtime-typing --py37-plus **/*.py
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,6 +20,6 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: cp config.py.sample config.py
       # Tests in test_wcdimportbot.py and test_wikicitations.py require a valid userid and password
-      - run: pytest --ignore=tests/test_wcdimportbot.py --ignore=tests/test_wikicitations.py .
+      - run: pytest --ignore=tests/test_wcdimportbot.py .
       - run: shopt -s globstar && pyupgrade --keep-runtime-typing --py37-plus **/*.py
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,6 +20,6 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: cp config.py.sample config.py
       # Tests in test_wcdimportbot.py and test_wikicitations.py require a valid userid and password
-      - run: pytest --ignore=tests/test_wcdimportbot.py .
+      - run: pytest --durations=10 --ignore=tests/test_wcdimportbot.py .
       - run: shopt -s globstar && pyupgrade --keep-runtime-typing --py37-plus **/*.py
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -18,6 +18,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
+      - run: cp config.py.sample config.py
       - run: pytest . || true
       - run: shopt -s globstar && pyupgrade --keep-runtime-typing --py37-plus **/*.py
       - run: safety check

--- a/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
+++ b/src/models/wikimedia/wikipedia/templates/wikipedia_page_reference.py
@@ -442,7 +442,7 @@ class WikipediaPageReference(BaseModel):
     def __find_number__(string: str) -> Optional[int]:
         """Find all numbers in a string"""
         # logger.debug(f"Trying to find numbers in: {string}.")
-        numbers = re.findall("\d+", string)
+        numbers = re.findall(r"\d+", string)
         if len(numbers) == 1:
             return int(numbers[0])
         elif len(numbers) > 1:

--- a/tests/test_wikicitations.py
+++ b/tests/test_wikicitations.py
@@ -1,9 +1,11 @@
 import logging
+from os import getenv
 from time import sleep
 from typing import List
 from unittest import TestCase
 from requests import HTTPError
 
+import pytest
 from pydantic import ValidationError
 from wikibaseintegrator.models import Claim  # type: ignore
 from wikibaseintegrator.wbi_exceptions import MWApiError  # type: ignore
@@ -21,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestWikiCitations(TestCase):
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_prepare_new_reference_item(self):
         from src.models.wikicitations import WikiCitations
 
@@ -92,6 +95,7 @@ class TestWikiCitations(TestCase):
 
         # logger.info(f"url: {wppage.wikicitations_url}")
 
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_prepare_new_wikipedia_page_item_valid_qid(self):
         from src.models.wikicitations import WikiCitations
 
@@ -134,6 +138,7 @@ class TestWikiCitations(TestCase):
         assert citations[0].mainsnak.datavalue["value"]["id"] == "Q1"
         # logger.info(f"url: {wppage.wikicitations_url}")
 
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_prepare_and_upload_wikipedia_page_item_valid_qid(self):
         wc = WikiCitations(
             language_code="en", language_wcditem=WCDItem.ENGLISH_WIKIPEDIA
@@ -205,6 +210,7 @@ class TestWikiCitations(TestCase):
         with self.assertRaises(ValidationError):
             wc.entity_url()
 
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_get_all_page_items(self):
         # first import a page to make sure there is at least one to be found
         bot = WcdImportBot()
@@ -227,6 +233,7 @@ class TestWikiCitations(TestCase):
         # if items is None or len(items) == 0:
         #     self.fail("Got no items")
 
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_get_all_reference_items(self):
         # first import a page with at least one reference
         # to make sure there is at least one to be found
@@ -255,6 +262,7 @@ class TestWikiCitations(TestCase):
         with self.assertRaises(HTTPError):
             wc.__get_items_via_sparql__(query="test")
 
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_prepare_and_upload_website_item(self):
         wc = WikiCitations(
             language_code="en", language_wcditem=WCDItem.ENGLISH_WIKIPEDIA
@@ -283,6 +291,7 @@ class TestWikiCitations(TestCase):
         bot = WcdImportBot()
         bot.rinse_all_items_and_cache()
 
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_uploading_a_page_reference_and_website_item(self):
         wc = WikiCitations(
             language_code="en", language_wcditem=WCDItem.ENGLISH_WIKIPEDIA

--- a/tests/test_wikicitations.py
+++ b/tests/test_wikicitations.py
@@ -210,7 +210,7 @@ class TestWikiCitations(TestCase):
         with self.assertRaises(ValidationError):
             wc.entity_url()
 
-    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
+    @pytest.mark.skipif(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_get_all_page_items(self):
         # first import a page to make sure there is at least one to be found
         bot = WcdImportBot()
@@ -233,7 +233,7 @@ class TestWikiCitations(TestCase):
         # if items is None or len(items) == 0:
         #     self.fail("Got no items")
 
-    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
+    @pytest.mark.skipif(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_get_all_reference_items(self):
         # first import a page with at least one reference
         # to make sure there is at least one to be found

--- a/tests/test_wikipedia_page.py
+++ b/tests/test_wikipedia_page.py
@@ -72,7 +72,7 @@ class TestWikipediaPage(TestCase):
         assert page.page_id == 11089416
         assert page.title == "Test"
 
-    @pytest.mark.xfail(getenv("CI", ""), reason="GitHub Actions do not have passwords")
+    @pytest.mark.xfail(bool(getenv("CI")), reason="GitHub Actions do not have logins")
     def test_get_wcdqid_from_hash_via_sparql(self):
         page = WikipediaPage(
             language_code="en", wikimedia_site=WikimediaSite.WIKIPEDIA, title="Test"

--- a/tests/test_wikipedia_page.py
+++ b/tests/test_wikipedia_page.py
@@ -1,6 +1,9 @@
 import logging
+from os import getenv
 from time import sleep
 from unittest import TestCase
+
+import pytest
 
 import config
 from src import WikipediaPage, WikimediaSite, console
@@ -69,6 +72,7 @@ class TestWikipediaPage(TestCase):
         assert page.page_id == 11089416
         assert page.title == "Test"
 
+    @pytest.mark.xfail(getenv("CI"), reason="GitHub Actions do not yet have passwords")
     def test_get_wcdqid_from_hash_via_sparql(self):
         page = WikipediaPage(
             language_code="en", wikimedia_site=WikimediaSite.WIKIPEDIA, title="Test"

--- a/tests/test_wikipedia_page.py
+++ b/tests/test_wikipedia_page.py
@@ -72,7 +72,7 @@ class TestWikipediaPage(TestCase):
         assert page.page_id == 11089416
         assert page.title == "Test"
 
-    @pytest.mark.xfail(getenv("CI"), reason="GitHub Actions do not yet have passwords")
+    @pytest.mark.xfail(getenv("CI", ""), reason="GitHub Actions do not have passwords")
     def test_get_wcdqid_from_hash_via_sparql(self):
         page = WikipediaPage(
             language_code="en", wikimedia_site=WikimediaSite.WIKIPEDIA, title="Test"


### PR DESCRIPTION
Trying to get pytest to pass on GitHub Actions...
* `pytest --ignore` test_wcdimportbot.py and test_wikicitations.py because some tests require a valid userid and password.

@dpriskorn Can you please help me understand why two pytests that are failing on `__find_number__(string='isbn_13')`

Should `__find_number__()` be changed or should the pytests be changed?